### PR TITLE
fix a bug when called in background thread

### DIFF
--- a/src/com/hipmob/gifanimationdrawable/GifAnimationDrawable.java
+++ b/src/com/hipmob/gifanimationdrawable/GifAnimationDrawable.java
@@ -71,7 +71,7 @@ public class GifAnimationDrawable extends AnimationDrawable
         setOneShot(mGifDecoder.getLoopCount() != 0);
         setVisible(true, true);
 		if(inline){
-			run();
+			loader.run();
 		}else{
 			new Thread(loader).start();
 		}


### PR DESCRIPTION
GifAnimationDrawable will not be decoded when loading it in a
background thread cuz the decode code is called uncorrectly. replace
run() with loader.run().
